### PR TITLE
Fix for global persistence issue in "MySQL databases not using PVC"

### DIFF
--- a/mysql/Chart.yaml
+++ b/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.4.0
+version: 0.4.1
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.
 keywords:

--- a/mysql/templates/_helpers.tpl
+++ b/mysql/templates/_helpers.tpl
@@ -29,3 +29,13 @@
     {{- printf "" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "mysqlDataVolume" -}}
+        - name: data
+  {{- if (or .Values.persistence.enabled .Values.global.persistence.enabled) }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "mysql.fullname" .) }}
+  {{- else }}
+          emptyDir: {}
+  {{- end -}}
+{{- end -}}

--- a/mysql/templates/deployment.yaml
+++ b/mysql/templates/deployment.yaml
@@ -80,10 +80,4 @@ spec:
         - name: data
           mountPath: /var/lib/mysql
       volumes:
-      - name: data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "mysql.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{- end -}}
+        {{ template "mysqlDataVolume" . }}


### PR DESCRIPTION
https://github.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/issues/75

Signed-off-by: Rick Osowski <osowski@us.ibm.com>

This is the source fix for the `resiliency/mysql` charts.  This needs to be propagated into `inventorymysql` and `ordersmysql` in https://github.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/tree/master/docs/charts